### PR TITLE
Remove back button

### DIFF
--- a/package/yast2-rmt.changes
+++ b/package/yast2-rmt.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct 29 12:57:32 UTC 2018 - thutterer@suse.com
+
+- version 1.1.1
+- Translation fixes
+- Remove broken back-buttons
+
+-------------------------------------------------------------------
 Mon Oct 29 10:04:20 UTC 2018 - thutterer@suse.com
 
 - version 1.1.0

--- a/package/yast2-rmt.spec
+++ b/package/yast2-rmt.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-rmt
-Version:        1.1.0
+Version:        1.1.1
 Release:        0
 BuildArch:      noarch
 

--- a/spec/rmt/wizard_scc_page_spec.rb
+++ b/spec/rmt/wizard_scc_page_spec.rb
@@ -30,7 +30,6 @@ describe RMT::WizardSCCPage do
       expect(Yast::Wizard).to receive(:SetAbortButton).with(:abort, Yast::Label.CancelButton)
       expect(Yast::Wizard).to receive(:SetNextButton).with(:next, Yast::Label.NextButton)
       expect(Yast::Wizard).to receive(:SetContents)
-      expect(Yast::Wizard).to receive(:DisableBackButton)
 
       expect(Yast::UI).to receive(:ChangeWidget).with(Id(:scc_username), :Value, config['scc']['username'])
       expect(Yast::UI).to receive(:ChangeWidget).with(Id(:scc_password), :Value, config['scc']['password'])

--- a/src/lib/rmt/wizard.rb
+++ b/src/lib/rmt/wizard.rb
@@ -66,6 +66,7 @@ class RMT::Wizard < Yast::Client
     }
 
     Wizard.CreateDialog
+    Wizard.HideBackButton
     Wizard.SetTitleIcon('yast-rmt')
 
     Sequencer.Run(aliases, sequence)

--- a/src/lib/rmt/wizard_firewall_page.rb
+++ b/src/lib/rmt/wizard_firewall_page.rb
@@ -38,6 +38,10 @@ class RMT::WizardFirewallPage < CWM::Dialog
     Yast::Label.CancelButton # to be consistent with the other pages
   end
 
+  def back_button
+    '' # omit the button
+  end
+
   def contents
     if firewalld.installed? && firewalld.enabled?
       HBox(

--- a/src/lib/rmt/wizard_rmt_service_page.rb
+++ b/src/lib/rmt/wizard_rmt_service_page.rb
@@ -40,7 +40,7 @@ class RMT::WizardRMTServicePage < Yast::Client
         HSpacing(1),
         VBox(
           HSquash(
-            Label(Id(:service_status), 'Service \'rmt-server\' started, sync and mirroring systemd timers active.')
+            Label(Id(:service_status), _("Service 'rmt-server' started, sync and mirroring systemd timers active."))
           )
         )
       )

--- a/src/lib/rmt/wizard_scc_page.rb
+++ b/src/lib/rmt/wizard_scc_page.rb
@@ -61,8 +61,6 @@ class RMT::WizardSCCPage < Yast::Client
       true
     )
 
-    Wizard.DisableBackButton
-
     UI.ChangeWidget(Id(:scc_username), :Value, @config['scc']['username'])
     UI.ChangeWidget(Id(:scc_password), :Value, @config['scc']['password'])
   end


### PR DESCRIPTION
So far the wizard is not meant to reconfigure RMT, but just for a
first-time setup. Because of that, some pages (database, ssl)
automatically go to the next page when their job is done already when
their are initialized. This broke the back button behavior. Since there
is no good reason to go back anyway at the moment, the fix for now is to
not even show a back button.

Fixes #13 